### PR TITLE
Create Third Umpire Decision Review System (DRS Gully Cricket) | Python

### DIFF
--- a/Third Umpire Decision Review System (DRS Gully Cricket) | Python
+++ b/Third Umpire Decision Review System (DRS Gully Cricket) | Python
@@ -1,0 +1,177 @@
+# All media file is available for download as a zip file (See description)
+
+import tkinter 
+
+import cv2 # pip install opencv-python
+
+import PIL.Image, PIL.ImageTk # pip install pillow
+
+from functools import partial
+
+import threading
+
+import time
+
+import imutils # pip install imutils
+
+stream = cv2.VideoCapture("clip.mp4")
+
+flag = True
+
+def play(speed):
+
+    global flag
+
+    print(f"You clicked on play. Speed is {speed}")
+
+    # Play the video in reverse mode
+
+    frame1 = stream.get(cv2.CAP_PROP_POS_FRAMES)
+
+    stream.set(cv2.CAP_PROP_POS_FRAMES, frame1 + speed)
+
+    grabbed, frame = stream.read()
+
+    if not grabbed:
+
+        exit()
+
+    frame = imutils.resize(frame, width=SET_WIDTH, height=SET_HEIGHT)
+
+    frame = PIL.ImageTk.PhotoImage(image = PIL.Image.fromarray(frame))
+
+    canvas.image = frame
+
+    canvas.create_image(0,0, image=frame, anchor=tkinter.NW)
+
+    if flag:
+
+        canvas.create_text(134, 26, fill="black", font="Times 26 bold", text="Decision Pending")
+
+    flag = not flag
+
+    
+
+def pending(decision):
+
+    # 1. Display decision pending image
+
+    frame = cv2.cvtColor(cv2.imread("pending.png"), cv2.COLOR_BGR2RGB)
+
+    frame = imutils.resize(frame, width=SET_WIDTH, height=SET_HEIGHT)
+
+    frame = PIL.ImageTk.PhotoImage(image=PIL.Image.fromarray(frame))
+
+    canvas.image = frame
+
+    canvas.create_image(0,0, image=frame, anchor=tkinter.NW)
+
+    # 2. Wait for 1 second
+
+    time.sleep(1.5)
+
+    # 3. Display sponsor image
+
+    frame = cv2.cvtColor(cv2.imread("sponsor.png"), cv2.COLOR_BGR2RGB)
+
+    frame = imutils.resize(frame, width=SET_WIDTH, height=SET_HEIGHT)
+
+    frame = PIL.ImageTk.PhotoImage(image=PIL.Image.fromarray(frame))
+
+    canvas.image = frame
+
+    canvas.create_image(0,0, image=frame, anchor=tkinter.NW)
+
+    # 4. Wait for 1.5 second
+
+    time.sleep(2.5)
+
+    # 5. Display out/notout image
+
+    if decision == 'out':
+
+        decisionImg = "out.png"
+
+    else:
+
+        decisionImg = "not_out.png"
+
+    frame = cv2.cvtColor(cv2.imread(decisionImg), cv2.COLOR_BGR2RGB)
+
+    frame = imutils.resize(frame, width=SET_WIDTH, height=SET_HEIGHT)
+
+    frame = PIL.ImageTk.PhotoImage(image=PIL.Image.fromarray(frame))
+
+    canvas.image = frame
+
+    canvas.create_image(0,0, image=frame, anchor=tkinter.NW)
+
+def out():
+
+    thread = threading.Thread(target=pending, args=("out",))
+
+    thread.daemon = 1
+
+    thread.start()
+
+    print("Player is out")
+
+def not_out():
+
+    thread = threading.Thread(target=pending, args=("not out",))
+
+    thread.daemon = 1
+
+    thread.start()
+
+    print("Player is not out")
+
+# Width and height of our main screen
+
+SET_WIDTH = 650
+
+SET_HEIGHT = 368
+
+# Tkinter gui starts here
+
+window = tkinter.Tk()
+
+window.title("CodeWithHarry Third Umpire Decision Review Kit")
+
+cv_img = cv2.cvtColor(cv2.imread("welcome.png"), cv2.COLOR_BGR2RGB)
+
+canvas = tkinter.Canvas(window, width=SET_WIDTH, height=SET_HEIGHT)
+
+photo = PIL.ImageTk.PhotoImage(image=PIL.Image.fromarray(cv_img))
+
+image_on_canvas = canvas.create_image(0, 0, ancho=tkinter.NW, image=photo)
+
+canvas.pack()
+
+# Buttons to control playback
+
+btn = tkinter.Button(window, text="<< Previous (fast)", width=50, command=partial(play, -25))
+
+btn.pack()
+
+btn = tkinter.Button(window, text="<< Previous (slow)", width=50, command=partial(play, -2))
+
+btn.pack()
+
+btn = tkinter.Button(window, text="Next (slow) >>", width=50, command=partial(play, 2))
+
+btn.pack()
+
+btn = tkinter.Button(window, text="Next (fast) >>", width=50, command=partial(play, 25))
+
+btn.pack()
+
+btn = tkinter.Button(window, text="Give Out", width=50, command=out)
+
+btn.pack()
+
+btn = tkinter.Button(window, text="Give Not Out", width=50, command=not_out)
+
+btn.pack()
+
+window.mainloop()


### PR DESCRIPTION
In today’s tutorial, we are going to create a “Third Umpire Decision Review System”

One of the most treasured memories of growing up is playing cricket with friends. Just like me, there are countless other people whose favourite part of the day is to grab a pair of bat and ball and just play. Gully cricket is the most popular form of sport, is played in everywhere. So, today’s project is going to be very helpful for those cricket fans who want to create their own decision review system. 

Prerequisite: The prerequisite of this project is the basic knowledge of python.

The third empire takes the decision about no-ball, runout, or catch out. Here we are going to make the decision review system using python which will take an accurate decision about whether the batsman is out or not out.